### PR TITLE
Added Coloured Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@
 <br/> 
 <h3>Languages and Tools:</h3>
 <br>
-<code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/nodejs/nodejs.png"></code>  
- <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/csharp/csharp.png"></code>   
-<code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/python/python.png"></code>  
-<code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/java/java.png"></code>  
-<code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/cpp/cpp.png"></code>  
- <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/javascript/javascript.png"></code>
- <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/c/c.png"></code>   
-  <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png"></code>  
-   <code><img height="20" src="https://avatars.githubusercontent.com/u/27973237?s=200&v=4"></code>  
+<code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/nodejs/nodejs.png"></code>  
+ <code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/csharp/csharp.png"></code>   
+<code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/python/python.png"></code>  
+<code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/java/java.png"></code>  
+<code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/cpp/cpp.png"></code>  
+ <code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/javascript/javascript.png"></code>
+ <code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/c/c.png"></code>   
+  <code><img height="30" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png"></code>  
+   <code><img height="30" src="https://avatars.githubusercontent.com/u/27973237?s=200&v=4"></code>  
 
 <br />
 
 ### Connect with me:
 <br />
 
-[<img align="left" alt="" width="22px" src="https://raw.githubusercontent.com/iconic/open-iconic/master/svg/globe.svg" />][website]
-[<img align="left" alt="codeSTACKr | YouTube" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/youtube.svg" />][youtube]
-[<img align="left" alt="codeSTACKr | Twitter" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg" />][twitter]
-[<img align="left" alt="codeSTACKr | LinkedIn" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/linkedin.svg" />][linkedin]
-[<img align="left" alt="codeSTACKr | Instagram" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/instagram.svg" />][instagram]
+[<img align="left" alt="" width="35px" src="https://cdn-icons.flaticon.com/png/512/869/premium/869183.png?token=exp=1642524962~hmac=d9e6b5995cdab7653964b6077049ccad" />][website]
+[<img align="left" alt="codeSTACKr | YouTube" width="35px" src="https://cdn-icons.flaticon.com/png/512/2504/premium/2504848.png?token=exp=1642524865~hmac=79fad6398131733968a137c1e5c0b778" />][youtube]
+[<img align="left" alt="codeSTACKr | Twitter" width="35px" src="https://cdn-icons-png.flaticon.com/512/145/145812.png" />][twitter]
+[<img align="left" alt="codeSTACKr | LinkedIn" width="35px" src="https://cdn-icons-png.flaticon.com/512/145/145807.png" />][linkedin]
+[<img align="left" alt="codeSTACKr | Instagram" width="35px" src="https://cdn-icons.flaticon.com/png/512/3955/premium/3955024.png?token=exp=1642524494~hmac=98fe3646c3d2b73ee5683adbb1a56228" />][instagram]
 
 <br />                    
                                                           


### PR DESCRIPTION
The previous icons in Connect with me section were black and transparent. GitHub is dark-themed, they were not visible. New coloured icons are much visible than before. 
The size of icons has been increased in the 'connect with me' and 'languages and tools' sections.